### PR TITLE
Update to .net 8, and NuGet update (July 2025)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: devpro/github-workflow-parts
-          ref: main
+          ref: feature/sonar-login-deprecation
           path: workflow-parts
       - name: Start MongoDB
         uses: ./workflow-parts/mongodb/start
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: devpro/github-workflow-parts
-          ref: main
+          ref: feature/sonar-login-deprecation
           path: workflow-parts
       - name: Create and scan container image
         uses: ./workflow-parts/docker/build-scan

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
  
   <PropertyGroup>
     <!-- edit this value to change the current MAJOR.MINOR.PATCH version -->
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
   </PropertyGroup>
  
   <Choose>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/devpro/terraform-backend-mongodb/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/devpro/terraform-backend-mongodb/actions/workflows/ci.yaml)
 [![PKG](https://github.com/devpro/terraform-backend-mongodb/actions/workflows/pkg.yaml/badge.svg?branch=main)](https://github.com/devpro/terraform-backend-mongodb/actions/workflows/pkg.yaml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=devpro.terraform-backend-mongodb&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=devpro.terraform-backend-mongodb)
-[![Docker Image Version](https://img.shields.io/docker/v/devprofr/terraform-backend-mongodb?label=Image)](https://hub.docker.com/r/devprofr/terraform-backend-mongodb)
+[![Docker Image Version](https://img.shields.io/docker/v/devprofr/terraform-backend-mongodb?label=Image&logo=docker)](https://hub.docker.com/r/devprofr/terraform-backend-mongodb)
 
 Store [Terraform](https://www.terraform.io) state in [MongoDB](https://www.mongodb.com/), using
 [HTTP](https://www.terraform.io/language/settings/backends/http) [backend](https://github.com/hashicorp/terraform/tree/main/internal/backend/remote-state).
@@ -58,22 +58,23 @@ This is a .NET 7 / C# codebase (open-source, cross-platform, free, object-orient
 
 ### Project structure
 
-Project name | Technology | Project type
------------- | ---------- | ------------
-`Common.AspNetCore` | .NET 7 | Library
-`Common.MongoDb` | .NET 7 | Library
-`Common.Runtime` | .NET 7 | Library
-`Domain` | .NET 7 | Library
-`Infrastructure.MongoDb` | .NET 7 | Library
-`WebApi` | ASP.NET 7 | Web application (REST API)
+Project name             | Technology | Project type
+------------------------ | ---------- | --------------------------
+`Common.AspNetCore`      | .NET 7     | Library
+`Common.MongoDb`         | .NET 7     | Library
+`Common.Runtime`         | .NET 7     | Library
+`Domain`                 | .NET 7     | Library
+`Infrastructure.MongoDb` | .NET 7     | Library
+`WebApi`                 | ASP.NET 7  | Web application (REST API)
 
 ### Packages (NuGet)
 
-Name | Description
----- | -----------
-`MongoDB.Bson`, `MongoDB.Driver` | MongoDB .NET Driver
+Name                     | Description
+------------------------ | ----------------------------
+`MongoDB.Bson`           | MongoDB BSON
+`MongoDB.Driver`         | MongoDB .NET Driver
 `Swashbuckle.AspNetCore` | OpenAPI / Swagger generation
-`System.Text.Json` | JSON support
+`System.Text.Json`       | JSON support
 
 ## How to compare
 

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ docker run --rm --link mongodb \
 
 ## How to contribute
 
-This is a .NET 7 / C# codebase (open-source, cross-platform, free, object-oriented technologies)
+This is a .NET 8 / C# codebase (open-source, cross-platform, free, object-oriented technologies)
 
 ### Project structure
 
 Project name             | Technology | Project type
 ------------------------ | ---------- | --------------------------
-`Common.AspNetCore`      | .NET 7     | Library
-`Common.MongoDb`         | .NET 7     | Library
-`Common.Runtime`         | .NET 7     | Library
-`Domain`                 | .NET 7     | Library
-`Infrastructure.MongoDb` | .NET 7     | Library
-`WebApi`                 | ASP.NET 7  | Web application (REST API)
+`Common.AspNetCore`      | .NET 8     | Library
+`Common.MongoDb`         | .NET 8     | Library
+`Common.Runtime`         | .NET 8     | Library
+`Domain`                 | .NET 8     | Library
+`Infrastructure.MongoDb` | .NET 8     | Library
+`WebApi`                 | ASP.NET 8  | Web application (REST API)
 
 ### Packages (NuGet)
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,7 @@ services:
       - MongoDb__ConnectionStringName=MongoDbLocal
       - MongoDb__DatabaseName=terraform_backend_dev
     ports:
-      - "9001:80"
+      - "9001:8080"
     depends_on:
       - mongodb
   mongodb:

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -11,9 +11,9 @@ which is defined in [`.gitlab-ci.yml`](../.gitlab-ci.yml) file.
 
 * Add the following variables
 
-Name | Value | Protected | Masked
----- | ----- | --------- | ------
-SONAR_ORGANIZATION | Sonar Organization | No | No
-SONAR_PROJECTKEY | Sonar Project Key | No | No
-SONAR_HOSTURL | Sonar Instance URL | No | No
-SONAR_TOKEN | Sonar Key | No | Yes
+Name               | Value              | Protected | Masked
+------------------ | ------------------ | --------- | ------
+SONAR_ORGANIZATION | Sonar Organization | No        | No
+SONAR_PROJECTKEY   | Sonar Project Key  | No        | No
+SONAR_HOSTURL      | Sonar Instance URL | No        | No
+SONAR_TOKEN        | Sonar Key          | No        | Yes

--- a/src/Common.AspNetCore.WebApi/Common.AspNetCore.WebApi.csproj
+++ b/src/Common.AspNetCore.WebApi/Common.AspNetCore.WebApi.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-rc.4" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>

--- a/src/Common.AspNetCore.WebApi/Common.AspNetCore.WebApi.csproj
+++ b/src/Common.AspNetCore.WebApi/Common.AspNetCore.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.Common.AspNetCore.WebApi</AssemblyName>
     <RootNamespace>Devpro.Common.AspNetCore.WebApi</RootNamespace>
     <ProjectGuid>{19336002-C959-4E76-B112-861F93CF6423}</ProjectGuid>
@@ -11,8 +11,8 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.18" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />

--- a/src/Common.AspNetCore.WebApi/Common.AspNetCore.WebApi.csproj
+++ b/src/Common.AspNetCore.WebApi/Common.AspNetCore.WebApi.csproj
@@ -11,15 +11,15 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.9" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.5.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.5.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol.Logs" Version="1.4.0-rc.4" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.1.0-rc.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/Common.AspNetCore/Common.AspNetCore.csproj
+++ b/src/Common.AspNetCore/Common.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.Common.AspNetCore</AssemblyName>
     <RootNamespace>Devpro.Common.AspNetCore</RootNamespace>
     <ProjectGuid>{F23098F5-355B-46F0-BABE-3D6E23D8EED7}</ProjectGuid>

--- a/src/Common.AspNetCore/README.md
+++ b/src/Common.AspNetCore/README.md
@@ -2,8 +2,6 @@
 
 Enrichment of [ASP.NET library](https://github.com/dotnet/aspnetcore).
 
-## Content
-
-### Classes
+## Classes
 
 * `RawRequestBodyFormatter`

--- a/src/Common.MongoDb/Common.MongoDb.csproj
+++ b/src/Common.MongoDb/Common.MongoDb.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.19.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
+    <PackageReference Include="MongoDB.Bson" Version="2.20.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Common.MongoDb/Common.MongoDb.csproj
+++ b/src/Common.MongoDb/Common.MongoDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.Common.MongoDb</AssemblyName>
     <RootNamespace>Devpro.Common.MongoDb</RootNamespace>
     <ProjectGuid>{49BF313A-4ED3-4BD2-9AEE-E44A5ED19C0C}</ProjectGuid>

--- a/src/Common.MongoDb/README.md
+++ b/src/Common.MongoDb/README.md
@@ -2,13 +2,11 @@
 
 Enrichments of [MongoDB .NET driver](https://mongodb.github.io/mongo-csharp-driver/) ([GitHub repository](https://github.com/mongodb/mongo-csharp-driver)).
 
-## Content
-
-### Interfaces
+## Interfaces
 
 * `IMongoClientFactory`
 
-### Classes
+## Classes
 
 * `DefaultMongoClientFactory`
 * `MongoDbConfiguration`

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.19.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="MongoDB.Bson" Version="2.20.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Bson" Version="2.20.0" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="System.Text.Json" Version="9.0.7" />
   </ItemGroup>
 
 </Project>

--- a/src/Domain/Domain.csproj
+++ b/src/Domain/Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.TerraformBackend.Domain</AssemblyName>
     <RootNamespace>Devpro.TerraformBackend.Domain</RootNamespace>
     <ProjectGuid>{A5CAD112-C1E6-442B-BE0E-37C697030636}</ProjectGuid>

--- a/src/Infrastructure.MongoDb/Infrastructure.MongoDb.csproj
+++ b/src/Infrastructure.MongoDb/Infrastructure.MongoDb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.TerraformBackend.Infrastructure.MongoDb</AssemblyName>
     <RootNamespace>Devpro.TerraformBackend.Infrastructure.MongoDb</RootNamespace>
     <ProjectGuid>{0429A41A-2D3A-42D4-8736-5FC0F6F0FF0C}</ProjectGuid>

--- a/src/WebApi/Authentication/BasicAuthenticationHandler.cs
+++ b/src/WebApi/Authentication/BasicAuthenticationHandler.cs
@@ -7,13 +7,8 @@ using Microsoft.Extensions.Options;
 
 namespace Devpro.TerraformBackend.WebApi.Authentication
 {
-    public class BasicAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    public class BasicAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
     {
-        public BasicAuthenticationHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
-            : base(options, logger, encoder, clock)
-        {
-        }
-
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
         {
             // raises an error if no authorization header

--- a/src/WebApi/Dockerfile
+++ b/src/WebApi/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
-EXPOSE 80
+EXPOSE 8080
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/WebApi/WebApi.csproj", "src/WebApi/"]
 RUN dotnet restore "src/WebApi/WebApi.csproj"

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.TerraformBackend.WebApi</AssemblyName>
     <RootNamespace>Devpro.TerraformBackend.WebApi</RootNamespace>
     <ProjectGuid>{5CD7A689-5ADB-4207-972E-6FA881AF1B1C}</ProjectGuid>

--- a/test/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/test/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Devpro.TerraformBackend.WebApi.IntegrationTests</AssemblyName>
     <RootNamespace>Devpro.TerraformBackend.WebApi.IntegrationTests</RootNamespace>
     <ProjectGuid>{B055FFAF-8261-43B1-866A-12E289D5D7DC}</ProjectGuid>
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">

--- a/test/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
+++ b/test/WebApi.IntegrationTests/WebApi.IntegrationTests.csproj
@@ -10,16 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="JunitXml.TestLogger" Version="3.0.124" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Since .NET 7 is out of support, move to .NET 8. Also, updated NuGet packages to versions without security issues.